### PR TITLE
Fix recreation of keys on every execution

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@
 
 [ -e ./src/bitBetter/api/.keys ]  || mkdir ./src/bitBetter/api/.keys
 [ -e ./src/bitBetter/identity/.keys ]  || mkdir ./src/bitBetter/identity/.keys
+
 cp .keys/cert.cert ./src/bitBetter/api/.keys
 cp .keys/cert.cert ./src/bitBetter/identity/.keys
 

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # If there aren't any keys, generate them first.
-[ -e ./keys/cert.cert] || ./.keys/generate-keys.sh
+[ -e ./.keys/cert.cert ] || ./.keys/generate-keys.sh
 
-[ -e ./source/bitBetter/api/.keys ]  || mkdir ./src/bitBetter/api/.keys
-[ -e ./source/bitBetter/identity/.keys ]  || mkdir ./src/bitBetter/identity/.keys
+[ -e ./src/bitBetter/api/.keys ]  || mkdir ./src/bitBetter/api/.keys
+[ -e ./src/bitBetter/identity/.keys ]  || mkdir ./src/bitBetter/identity/.keys
 cp .keys/cert.cert ./src/bitBetter/api/.keys
 cp .keys/cert.cert ./src/bitBetter/identity/.keys
 


### PR DESCRIPTION
File paths in checks were wrong so `generate-keys.sh` was called every time `build.sh` is run. This causes overwriting of existing keys breaking all previously generated licenses.

This PR also fixes checking of existing `.keys` folders in `api` and `identity` source. This did not break anything but produces errors when system tries to create those folders when they already exists.