### PR TITLE
Make policies available in generated org licenses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following instructions are for unix-based systems (Linux, BSD, macOS), it is
 ## Dependencies
 Aside from docker, which you also need for Bitwarden, BitBetter requires the following:
 
-* Bitwarden (tested up to 1.32.0)
+* Bitwarden (tested with 1.33.0, might work on lower versions)
 * openssl (probably already installed on most Linux or WSL systems, any version should work)
 
 ## Setting up BitBetter

--- a/src/licenseGen/Program.cs
+++ b/src/licenseGen/Program.cs
@@ -358,6 +358,7 @@ namespace bitwardenSelfLicensor
             set("PlanType", (byte)6);
             set("Seats", (short)32767);
             set("MaxCollections", short.MaxValue);
+            set("UsePolicies", true);
             set("UseGroups", true);
             set("UseEvents", true);
             set("UseDirectory", true);
@@ -366,7 +367,7 @@ namespace bitwardenSelfLicensor
             set("MaxStorageGb", short.MaxValue);
             set("SelfHost", true);
             set("UsersGetPremium", true);
-            set("Version", 4);
+            set("Version", 6);
             set("Issued", DateTime.UtcNow);
             set("Refresh", DateTime.UtcNow.AddYears(100).AddMonths(-1));
             set("Expires", DateTime.UtcNow.AddYears(100));

--- a/src/licenseGen/Program.cs
+++ b/src/licenseGen/Program.cs
@@ -367,7 +367,7 @@ namespace bitwardenSelfLicensor
             set("MaxStorageGb", short.MaxValue);
             set("SelfHost", true);
             set("UsersGetPremium", true);
-            set("Version", 6);
+            set("Version", 5);
             set("Issued", DateTime.UtcNow);
             set("Refresh", DateTime.UtcNow.AddYears(100).AddMonths(-1));
             set("Expires", DateTime.UtcNow.AddYears(100));


### PR DESCRIPTION
BW 2.13.1 added the ability to configure policies for organizations. The feature has to be enabled in the org license file to be configurable, also license version 6 is required for this.