### PR TITLE
Make update-bitwarden.sh able to run non-interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem -passin pass:te
 
 To update Bitwarden, the provided `update-bitwarden.sh` script can be used. It will rebuild the BitBetter images and automatically update Bitwarden afterwards. Docker pull errors can be ignored for api and identity images.
 
+You can either run this script without providing any parameters in interactive mode (`./update-bitwarden.sh`) or by setting the parameters as follows, to run the script in non-interactive mode:
+```bash
+./update-bitwarden.sh param1 param2 param3
+```
+`param1`: The path to the directory containing your bwdata directory
+
+`param2`: If you want the docker-compose file to be overwritten (either `y` or `n`)
+
+`param3`: If you want the bitbetter images to be rebuild (either `y` or `n`)
+
 ## Generating Signed Licenses
 
 There is a tool included in the directory `src/licenseGen/` that will generate new individual and organization licenses. These licenses will be accepted by the modified Bitwarden because they will be signed by the certificate you generated in earlier steps.
@@ -141,3 +151,4 @@ In the past we have done so but they were not focused on the type of customer th
 <a name="#f1"><sup>1</sup></a> If you wish to change this you'll need to change the value that `src/licenseGen/Program.cs` uses for its `GenerateUserLicense` and `GenerateOrgLicense` calls. Remember, this is really unnecessary as this certificate does not represent any type of security-related certificate.
 
 <a name="#f2"><sup>2</sup></a>This tool builds on top of the `bitbetter/api` container image so make sure you've built that above using the root `./build.sh` script.
+

--- a/update-bitwarden.sh
+++ b/update-bitwarden.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-ask()
-{
-  declare -g $1="$2"
-  if [ -z "${!1}" ]; then
-    echo "$3"
-    read $1
+ask () {
+  local __resultVar=$1
+  local __result="$2"
+  if [ -z "$2" ]; then
+    read -p "$3" __result
   fi
+  eval $__resultVar="'$__result'"
 }
 
 SCRIPT_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/update-bitwarden.sh
+++ b/update-bitwarden.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+ask()
+{
+  declare -g $1="$2"
+  if [ -z "${!1}" ]; then
+    echo "$3"
+    read $1
+  fi
+}
 
 SCRIPT_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 BW_VERSION="$(curl --silent https://raw.githubusercontent.com/bitwarden/server/master/scripts/bitwarden.sh | grep 'COREVERSION="' | sed 's/^[^"]*"//; s/".*//')"
@@ -8,8 +16,8 @@ echo "Starting Bitwarden update, newest server version: $BW_VERSION"
 # Default path is the parent directory of the BitBetter location
 BITWARDEN_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
 
-# Get Bitwarden base from user (or keep default value)
-read -p "Enter Bitwarden base directory [$BITWARDEN_BASE]: " tmpbase
+# Get Bitwarden base from user (or keep default value) or use first argument
+ask tmpbase "$1" "Enter Bitwarden base directory [$BITWARDEN_BASE]: "
 BITWARDEN_BASE=${tmpbase:-$BITWARDEN_BASE}
 
 # Check if directory exists and is valid
@@ -18,7 +26,7 @@ BITWARDEN_BASE=${tmpbase:-$BITWARDEN_BASE}
 
 # Check if user wants to recreate the docker-compose override file
 RECREATE_OV="y"
-read -p "Rebuild docker-compose override? [Y/n]: " tmprecreate
+ask tmprecreate "$2" "Rebuild docker-compose override? [Y/n]: "
 RECREATE_OV=${tmprecreate:-$RECREATE_OV}
 
 if [[ $RECREATE_OV =~ ^[Yy]$ ]]
@@ -48,7 +56,7 @@ if [ $retval -ne 0 ]; then
     REBUILD_BB="y"
     REBUILD_BB_DESCR="[Y/n]"
 fi
-read -p "Rebuild BitBetter images? $REBUILD_BB_DESCR: " tmprebuild
+ask tmprebuild "$3" "Rebuild BitBetter images? $REBUILD_BB_DESCR: "
 REBUILD_BB=${tmprebuild:-$REBUILD_BB}
 
 if [[ $REBUILD_BB =~ ^[Yy]$ ]]


### PR DESCRIPTION
Implements the ability to run the update-bitwarden.sh non-interactive.

Now it can be executed like: 
### `./update-bitwarden.sh /path/to/dir n y`
without any interaction.
**But the old interactive way still works!**
That allows automated updates.

Because of the `declare -g` part the script requires bash > 4.2 to run