### PR TITLE
fix integer type

### DIFF
--- a/src/licenseGen/Program.cs
+++ b/src/licenseGen/Program.cs
@@ -404,7 +404,7 @@ namespace bitwardenSelfLicensor
             set("Enabled", true);
             set("Plan", "Custom");
             set("PlanType", (byte)6);
-            set("Seats", (short)32767);
+            set("Seats", (int)32767);
             set("MaxCollections", short.MaxValue);
             set("UsePolicies", true);
             set("UseSso", true);


### PR DESCRIPTION
fix integer type for GenerateOrgLicense's "Seats" value

Fixes #109 