### PR TITLE
update-bitwarden.sh: Fix relative path

### DIFF
--- a/update-bitwarden.sh
+++ b/update-bitwarden.sh
@@ -61,7 +61,7 @@ REBUILD_BB=${tmprebuild:-$REBUILD_BB}
 
 if [[ $REBUILD_BB =~ ^[Yy]$ ]]
 then
-    $BITWARDEN_BASE/BitBetter/build.sh
+    $SCRIPT_BASE/build.sh
     echo "BitBetter images updated to version: $BW_VERSION"
 fi
 

--- a/update-bitwarden.sh
+++ b/update-bitwarden.sh
@@ -61,7 +61,7 @@ REBUILD_BB=${tmprebuild:-$REBUILD_BB}
 
 if [[ $REBUILD_BB =~ ^[Yy]$ ]]
 then
-    ./build.sh
+    $BITWARDEN_BASE/BitBetter/build.sh
     echo "BitBetter images updated to version: $BW_VERSION"
 fi
 


### PR DESCRIPTION
update-bitwarden.sh attempted to update BitBetter via
./build.sh, but if run via crontab, you aren't in
the BitBetter directory.

Fixed to find it correctly.

Signed-off-by: Donald Hoskins <grommish@gmail.com>