### PR TITLE
Update bitwarden.sh path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 DIR=`dirname "$0"`
 DIR=`exec 2>/dev/null;(cd -- "$DIR") && cd -- "$DIR"|| cd "$DIR"; unset PWD; /usr/bin/pwd || /bin/pwd || pwd`
-BW_VERSION="$(curl --silent https://raw.githubusercontent.com/bitwarden/server/master/scripts/bitwarden.sh | grep 'COREVERSION="' | sed 's/^[^"]*"//; s/".*//')"
+BW_VERSION="$(curl --silent https://raw.githubusercontent.com/bitwarden/self-host/master/bitwarden.sh | grep 'COREVERSION="' | sed 's/^[^"]*"//; s/".*//')"
 
 echo "Building BitBetter for BitWarden version $BW_VERSION"
 

--- a/update-bitwarden.sh
+++ b/update-bitwarden.sh
@@ -9,7 +9,7 @@ ask () {
 }
 
 SCRIPT_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-BW_VERSION="$(curl --silent https://raw.githubusercontent.com/bitwarden/server/master/scripts/bitwarden.sh | grep 'COREVERSION="' | sed 's/^[^"]*"//; s/".*//')"
+BW_VERSION="$(curl --silent https://raw.githubusercontent.com/bitwarden/self-host/master/bitwarden.sh | grep 'COREVERSION="' | sed 's/^[^"]*"//; s/".*//')"
 
 echo "Starting Bitwarden update, newest server version: $BW_VERSION"
 


### PR DESCRIPTION
Bitwarden.sh script was moved yesterday and caused an error during BitBetter's build

Output before change:
```
Building BitBetter for BitWarden version 
+ dotnet add package Newtonsoft.Json --version 12.0.3
...
Sending build context to Docker daemon  2.993MB
Step 1/6 : ARG BITWARDEN_TAG
Step 2/6 : FROM ${BITWARDEN_TAG}
invalid reference format
Sending build context to Docker daemon  2.993MB
Step 1/6 : ARG BITWARDEN_TAG
Step 2/6 : FROM ${BITWARDEN_TAG}
invalid reference format
Error response from daemon: No such image: bitbetter/api:latest
Error response from daemon: No such image: bitbetter/identity:latest
Error parsing reference: "bitbetter/api:" is not a valid repository/tag: invalid reference format
Error parsing reference: "bitbetter/identity:" is not a valid repository/tag: invalid reference format
```

Output after change:
```
Building BitBetter for BitWarden version 1.46.2
+ dotnet add package Newtonsoft.Json --version 12.0.3
...
Successfully built 81cb395e875b
Successfully tagged bitbetter/api:latest
...
Successfully built ec2a0d378578
Successfully tagged bitbetter/identity:latest
```