### PR TITLE
Update License to use Secrets Manager Fully Issue #181

### DIFF
--- a/src/licenseGen/Program.cs
+++ b/src/licenseGen/Program.cs
@@ -414,8 +414,8 @@ namespace bitwardenSelfLicensor
             set("BillingEmail", email);
             set("BusinessName", string.IsNullOrWhiteSpace(businessName) ? "BitBetter" : businessName);
             set("Enabled", true);
-            set("Plan", "Custom");
-            set("PlanType", Enum.Parse(planTypeEnum, "Custom"));
+            set("Plan", "Enterprise (Annually)");
+            set("PlanType", Enum.Parse(planTypeEnum, "EnterpriseAnnually"));
             set("Seats", int.MaxValue);
             set("MaxCollections", short.MaxValue);
             set("UsePolicies", true);
@@ -437,12 +437,13 @@ namespace bitwardenSelfLicensor
             set("UseSecretsManager", true);
             set("SmSeats", int.MaxValue);
             set("SmServiceAccounts", int.MaxValue);
-            set("Version", 12);
+            set("Version", 14); //This is set to 14 to use LimitCollectionCreationDeletion can be changed to 13 to just use Secrets Manager
             set("Issued", DateTime.UtcNow);
             set("Refresh", DateTime.UtcNow.AddYears(100).AddMonths(-1));
             set("Expires", DateTime.UtcNow.AddYears(100));
             set("Trial", false);
             set("LicenseType", Enum.Parse(licenseTypeEnum, "Organization"));
+            set("LimitCollectionCreationDeletion", true); //This will be used in the new version of BitWarden but can be applied now
 
             set("Hash", Convert.ToBase64String((byte[])type.GetMethod("ComputeHash").Invoke(license, new object[0])));
             set("Signature", Convert.ToBase64String((byte[])type.GetMethod("Sign").Invoke(license, new object[] { cert })));


### PR DESCRIPTION
Updated License to be Enterprise (Annually) - The License will still expire in 100years based on expiry date not annually 

Updated Version to 14 and included LimitCollectionCreationDeletion which will be used in next Bitwarden version
