### PR TITLE
Update Dockerfile

### DIFF
--- a/src/licenseGen/Dockerfile
+++ b/src/licenseGen/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 WORKDIR /licenseGen
 


### PR DESCRIPTION
Fixed a issue with the DOCKERFILE not allowing building.

The previous error was as follows:

![WindowsTerminal_3z2MC30St4](https://github.com/user-attachments/assets/a744d380-0284-488e-99fb-f1993a7c5a01)

This error is now fixed and the file builds correctly with this fix:

![WindowsTerminal_fa741u37fc](https://github.com/user-attachments/assets/fb7b37f0-c3ad-4791-bc34-191becf99e3c)
