### PR TITLE
Prevent docker compose from attempting to pull BitBetter images from the Docker repository

### DIFF
--- a/update-bitwarden.sh
+++ b/update-bitwarden.sh
@@ -35,9 +35,11 @@ then
         echo "services:"
         echo "  api:"
         echo "    image: bitbetter/api:$BW_VERSION"
+        echo "    pull_policy: never"
         echo ""
         echo "  identity:"
         echo "    image: bitbetter/identity:$BW_VERSION"
+        echo "    pull_policy: never"        
         echo ""
     } > $BITWARDEN_BASE/bwdata/docker/docker-compose.override.yml
     echo "BitBetter docker-compose override created!"


### PR DESCRIPTION
This pull request modifies the creation of docker-compose.override.yml by adding additional YAML parameters, preventing Docker from pulling images from Docker Hub. This is not necessary, as the images are built by BitBetter and are therefore located locally on the machine where BitBetter is built.