### PR TITLE
Updated container repository

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,8 +15,8 @@ cp "$DIR/.keys/cert.cert" "$DIR/src/bitBetter/.keys"
 
 docker run --rm -v "$DIR/src/bitBetter:/bitBetter" -w=/bitBetter mcr.microsoft.com/dotnet/sdk:8.0 sh build.sh
 
-docker build --no-cache --build-arg BITWARDEN_TAG=bitwarden/api:$BW_VERSION --label com.bitwarden.product="bitbetter" -t bitbetter/api "$DIR/src/bitBetter" # --squash
-docker build --no-cache --build-arg BITWARDEN_TAG=bitwarden/identity:$BW_VERSION --label com.bitwarden.product="bitbetter" -t bitbetter/identity "$DIR/src/bitBetter" # --squash
+docker build --no-cache --build-arg BITWARDEN_TAG=ghcr.io/bitwarden/api:$BW_VERSION --label com.bitwarden.product="bitbetter" -t bitbetter/api "$DIR/src/bitBetter" # --squash
+docker build --no-cache --build-arg BITWARDEN_TAG=ghcr.io/bitwarden/identity:$BW_VERSION --label com.bitwarden.product="bitbetter" -t bitbetter/identity "$DIR/src/bitBetter" # --squash
 
 docker tag bitbetter/api bitbetter/api:latest
 docker tag bitbetter/identity bitbetter/identity:latest


### PR DESCRIPTION
Since the 2025.3.0 update, the Bitwarden images are hosted on the GitHub Container Registry, officially moving them away from Docker Hub.
This PR fixes #224.