### PR TITLE
Update Unified branch to account for move from Docker Hub to GHCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ The scripts supports running and patching multi instances.
 Edit the .servers/serverlist.txt file and fill in the missing values, they can be replaced with existing installation values.
 This file may be empty, but there will be no containers will be spun up automatically.
 
-Now it is time to **run the main build script** to generate a modified version of the `bitwarden/self-host` docker image and the license generator.
+Now it is time to **run the main build script** to generate a modified version of the `ghcr.io/bitwarden/self-host` docker image and the license generator.
 
 From the BitBetter directory, simply run:
 ```
 ./build.[sh|ps1]
 ```
 
-This will create a new self-signed certificate in the `.keys` directory if one does not already exist and then create a modified version of the official `bitwarden/self-host` image called `bitwarden-patch`.
+This will create a new self-signed certificate in the `.keys` directory if one does not already exist and then create a modified version of the official `ghcr.io/bitwarden/self-host` image called `bitwarden-patch`.
 
 Afterwards it will automatically generate the license generator and start all previously specified containers which are **now ready to accept self-issued licenses.**
 

--- a/build.ps1
+++ b/build.ps1
@@ -45,13 +45,13 @@ foreach ($instance in $oldinstances) {
 # update bitwarden itself
 if ($args[0] -eq 'y')
 {
-	docker pull bitwarden/self-host:beta
+	docker pull ghcr.io/bitwarden/self-host:beta
 }
 else
 {
 	$confirmation = Read-Host "Update (or get) bitwarden source container"
 	if ($confirmation -eq 'y') {
-		docker pull bitwarden/self-host:beta
+		docker pull ghcr.io/bitwarden/self-host:beta
 	}
 }
 
@@ -61,7 +61,7 @@ docker rm bitwarden-patch
 docker image rm bitwarden-patch
 
 # start a new bitwarden instance so we can patch it
-$patchinstance = docker run -d --name bitwarden-patch bitwarden/self-host:beta
+$patchinstance = docker run -d --name bitwarden-patch ghcr.io/bitwarden/self-host:beta
 
 # create our temporary directory
 New-item -ItemType Directory -Path $tempdirectory

--- a/build.sh
+++ b/build.sh
@@ -47,13 +47,13 @@ done
 
 # update bitwarden itself
 if [ "$1" = "y" ]; then
-	docker pull bitwarden/self-host:beta
+	docker pull ghcr.io/bitwarden/self-host:beta
 else
 	read -p "Update (or get) bitwarden source container: " -n 1 -r
 	echo
 	if [[ $REPLY =~ ^[Yy]$ ]]
 	then
-		docker pull bitwarden/self-host:beta
+		docker pull ghcr.io/bitwarden/self-host:beta
 	fi
 fi
 
@@ -63,7 +63,7 @@ docker rm bitwarden-patch
 docker image rm bitwarden-patch
 
 # start a new bitwarden instance so we can patch it
-PATCHINSTANCE=$(docker run -d --name bitwarden-patch bitwarden/self-host:beta)
+PATCHINSTANCE=$(docker run -d --name bitwarden-patch ghcr.io/bitwarden/self-host:beta)
 
 # create our temporary directory
 mkdir $TEMPDIRECTORY

--- a/src/bitBetter/Dockerfile-bitwarden-patch
+++ b/src/bitBetter/Dockerfile-bitwarden-patch
@@ -1,4 +1,4 @@
-FROM bitwarden/self-host:beta
+FROM ghcr.io/bitwarden/self-host:beta
 
 COPY ./temp/Api/Core.dll /app/Api/Core.dll
 COPY ./temp/Identity/Core.dll /app/Identity/Core.dll


### PR DESCRIPTION
Change instances of "bitwarden/self-host" to "ghcr.io/bitwarden/self-host" to account for move to GHCR by Bitwarden. This PR fixed #224.