### PR TITLE
Fix line endings in serverlist.txt before executing commands

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -91,7 +91,8 @@ cp -f "$TEMPDIRECTORY/Identity/Core.dll" "$PWD/src/licenseGen"
 rm -rf "$TEMPDIRECTORY"
 
 # start all user requested instances
-cat "$PWD/.servers/serverlist.txt" | while read LINE; do
+sed -i 's/\r$//' "$PWD/.servers/serverlist.txt"
+cat "$PWD/.servers/serverlist.txt" | while read -r LINE; do
 	bash -c "$LINE"
 done
 


### PR DESCRIPTION
I encountered an issue when attempting to run `docker-compose` from the `serverlist.txt` file in Linux.
It appears that the file is partially in Windows format.
However, after editing it with `nano`, it will be fully in Windows format, with a trailing `\r` at the end of each line.
The `bash -c "$LINE"` command does not appear to run properly if the `LINE` string contains a trailing `\r`.

Take a look at the line endings before and after the editing process (note the `^M` = trailing `\r`):
```
diff -Naur serverlist_original.txt serverlist_edited.txt | cat -vet
--- serverlist_original.txt^I2025-06-07 19:24:17.289317351 +0200$
+++ serverlist_edited.txt^I2025-06-07 19:47:37.169415290 +0200$
@@ -1,3 +1,3 @@$
-docker run -d --name bitwarden -v <full-local-path>\logs:/var/log/bitwarden -v <full-local-path>\bwdata:/etc/bitwarden -p 80:8080 --env-file <full-local-path>\settings.env bitwarden-patch^M$
-<OR>^M$
-docker-compose -f <full-local-path>/docker-compose.yml up -d$
\ No newline at end of file$
+#docker run -d --name bitwarden -v <full-local-path>\logs:/var/log/bitwarden -v <full-local-path>\bwdata:/etc/bitwarden -p 80:8080 --env-file <full-local-path>\settings.env bitwarden-patch^M$
+#<OR>^M$
+docker-compose -f /etc/bitwarden/docker-compose.yml up -d^M$
```