### PR TITLE
Update Program.cs

### DIFF
--- a/src/licenseGen/Program.cs
+++ b/src/licenseGen/Program.cs
@@ -438,7 +438,9 @@ internal class Program
         Set("LicenseType", Enum.Parse(licenseTypeEnum, "Organization"));
 		Set("LimitCollectionCreationDeletion", true); //This will be used in the new version of BitWarden but can be applied now
 		Set("AllowAdminAccessToAllCollectionItems", true); 
-
+	Set("UseRiskInsights", true);
+        Set("UseOrganizationDomains", true);
+        Set("UseAdminSponsoredFamilies", true);
         Set("Hash", Convert.ToBase64String((Byte[])type.GetMethod("ComputeHash").Invoke(license, [])));
         Set("Signature", Convert.ToBase64String((Byte[])type.GetMethod("Sign").Invoke(license, [cert])));
 


### PR DESCRIPTION
Set three new license options to true: UseRiskInsights, UseOrganizationDomains, and UseAdminSponsoredFamilies.

As mentioned in #229, licenses had to be regenerated starting in 2025.5.0. It looks like new options were added which default to false unless we set them to true here. I am not sure if the version needs to be bumped or not. I tested locally and I can now access the Claimed Domains page in my organization.