### PR TITLE
[unified] Fix patch according to upstream changes and fix build errors

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -39,7 +39,7 @@ Remove-Item "$pwd\src\bitBetter\cert.cert" -Force
 # gather all running instances
 $oldinstances = docker container ps --all -f Name=bitwarden --format '{{.ID}}'
 
-# stop all running instances
+# stop and remove all running instances
 foreach ($instance in $oldinstances) {
 	docker stop $instance
 	docker rm $instance
@@ -58,10 +58,10 @@ else
 	}
 }
 
-# stop and remove previous existing patch(ed) container
-docker stop bitwarden-patch
-docker rm bitwarden-patch
-docker image rm bitwarden-patch
+# remove previous existing patch(ed) image
+if (docker image ls -q bitwarden-patch) {
+    docker image rm bitwarden-patch
+}
 
 # start a new bitwarden instance so we can patch it
 $patchinstance = docker run -d --name bitwarden-patch ghcr.io/bitwarden/self-host:beta

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ rm -f "$PWD/src/bitBetter/cert.cert"
 # gather all running instances
 OLDINSTANCES=$(docker container ps --all -f Name=bitwarden --format '{{.ID}}')
 
-# stop all running instances
+# stop and remove all running instances
 for INSTANCE in ${OLDINSTANCES[@]}; do
 	docker stop $INSTANCE
 	docker rm $INSTANCE
@@ -58,10 +58,10 @@ else
 	fi
 fi
 
-# stop and remove previous existing patch(ed) container
-docker stop bitwarden-patch
-docker rm bitwarden-patch
-docker image rm bitwarden-patch
+# remove previous existing patch(ed) image
+if [ "$(docker image ls -q bitwarden-patch)" ]; then
+	docker image rm bitwarden-patch
+fi
 
 # start a new bitwarden instance so we can patch it
 PATCHINSTANCE=$(docker run -d --name bitwarden-patch ghcr.io/bitwarden/self-host:beta)

--- a/src/bitBetter/Program.cs
+++ b/src/bitBetter/Program.cs
@@ -41,7 +41,7 @@ internal class Program
 
             Console.WriteLine($"New Cert Thumbprint: {certificate.Thumbprint}");
 
-            IEnumerable<TypeDef> services = moduleDefMd.Types.Where(t => t.Namespace == "Bit.Core.Services");
+            IEnumerable<TypeDef> services = moduleDefMd.Types.Where(t => t.Namespace == "Bit.Core.Billing.Services");
             TypeDef type = services.First(t => t.Name == "LicensingService");
             MethodDef constructor = type.FindConstructors().First();
             


### PR DESCRIPTION
Fix bitBetter patch to align with upstream changes, which are already included in the unified beta and dev images.
https://github.com/bitwarden/server/blob/30300bc59beae15d615dd12e3f4e6d3d3e1514bb/src/Core/Billing/Services/Implementations/LicensingService.cs#L27

Fix the builds by removing a redundant, already removed and stopped old instance. (Note: `build.ps1` has not been tested, please verify it.)
Issues: https://github.com/jakeswenson/BitBetter/issues/241, https://github.com/jakeswenson/BitBetter/issues/242