### PR TITLE
Fix licenseGen according to upstream changes

### DIFF
--- a/src/licenseGen/Dockerfile
+++ b/src/licenseGen/Dockerfile
@@ -12,4 +12,4 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0
 WORKDIR /app
 COPY --from=build /app .
 
-ENTRYPOINT [ "dotnet", "/app/licenseGen.dll", "--core", "/app/Core.dll", "--executable", "/app/Api", "--cert", "/app/cert.pfx" ]
+ENTRYPOINT [ "dotnet", "/app/licenseGen.dll", "--core", "/app/Core.dll", "--cert", "/app/cert.pfx" ]

--- a/src/licenseGen/Program.cs
+++ b/src/licenseGen/Program.cs
@@ -53,7 +53,7 @@ internal class Program
                 }
 
                 Console.WriteLine("Interactive license mode...");
-                
+
                 while (licenseType == "")
                 {
                     Console.WriteLine("What would you like to generate, a [u]ser license or an [o]rg license: ");
@@ -238,7 +238,7 @@ internal class Program
             CommandArgument storage = config.Argument("Storage", "extra storage space in GB. Maximum is " + Int16.MaxValue + " (optional, default = max)");
             CommandArgument businessName = config.Argument("BusinessName", "name for the organization (optional)");
             CommandArgument key = config.Argument("Key", "your key id (optional)");
-            
+
             config.OnExecute(() =>
             {
                 if (!VerifyTopOptions())
@@ -360,7 +360,7 @@ internal class Program
     {
         Assembly core = AssemblyLoadContext.Default.LoadFromAssemblyPath(corePath);
 
-        Type type = core.GetType("Bit.Core.Models.Business.UserLicense");
+        Type type = core.GetType("Bit.Core.Billing.Models.Business.UserLicense");
         Type licenseTypeEnum = core.GetType("Bit.Core.Enums.LicenseType");
 
         Object license = Activator.CreateInstance(type);
@@ -393,7 +393,7 @@ internal class Program
     {
         Assembly core = AssemblyLoadContext.Default.LoadFromAssemblyPath(corePath);
 
-        Type type = core.GetType("Bit.Core.Models.Business.OrganizationLicense");
+        Type type = core.GetType("Bit.Core.Billing.Models.Business.OrganizationLicense");
         Type licenseTypeEnum = core.GetType("Bit.Core.Enums.LicenseType");
         Type planTypeEnum = core.GetType("Bit.Core.Billing.Enums.PlanType");
 


### PR DESCRIPTION
Dockerfile: remove not existing executable argument
licenseGen: fix classes according to upstream changes

Warning: This patch only works when used together with https://github.com/jakeswenson/BitBetter/pull/243.