### PR TITLE
[Unified] Test generating user and organization licenses during build check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,3 +13,9 @@ jobs:
       - run:
           name: Build script
           command: ./build.sh y
+      - run:
+          name: Test generating user license
+          command: ./licenseGen.sh user TestName TestEmail@example.com 4a619d4a-522d-4c70-8596-affb5b607c23
+      - run:
+          name: Test generating organization license
+          command: ./licenseGen.sh org TestName TestEmail@example.com 4a619d4a-522d-4c70-8596-affb5b607c23


### PR DESCRIPTION
Add commands to build check to test if the created licensegen image can actually generate user and organization licenses. licenseGen.sh will print the generated license to stdout and return zero if successful. If an error occurs, a non zero error code is returned which should cause a build error.

Having this check would have caught #250. If we can't generate licensees, there is still a problem that needs to be fixed. Seems most likely to be caused by upstream changes so code which passes the tests today could fail in the future if something changes upstream. Only way I see to fix that would be to check if the current code still builds on some interval, say daily, so that its clear when any change from upstream that impact this project occurs. If we only run tests on new commits it will be hard to know if the test starting failing because of the commit or an upstream change.

Something similar could be done for master.