### PR TITLE
Test generating user and organization licenses during build check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,3 +13,12 @@ jobs:
       - run:
           name: Build script
           command: ./build.sh
+      - run:
+          name: Build licenseGen
+          command: ./src/licenseGen/build.sh
+      - run:
+          name: Test generating user license
+          command: ./src/licenseGen/run.sh ./.keys/cert.pfx user TestName TestEmail@example.com 4a619d4a-522d-4c70-8596-affb5b607c23
+      - run:
+          name: Test generating organization license
+          command: ./src/licenseGen/run.sh ./.keys/cert.pfx org TestName TestEmail@example.com 4a619d4a-522d-4c70-8596-affb5b607c23


### PR DESCRIPTION
Add commands to build check to build licensegen image as well and test if the created licensegen image can actually generate user and organization licenses. run.sh will print the generated license to stdout and return zero if successful. If an error occurs, a non zero error code is returned which should cause a build error.

Same as #251 except for master. Here also needed to actually build licensegen image before testing.