### PR TITLE
Enable buildkit

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -4,6 +4,10 @@ $PSNativeCommandUseErrorActionPreference = $true
 # detect buildx, ErrorActionPreference will ensure the script stops execution if not found
 docker buildx version
 
+# Enable BuildKit for better build experience and to ensure platform args are populated
+$env:DOCKER_BUILDKIT=1
+$env:COMPOSE_DOCKER_CLI_BUILD=1
+
 # define temporary directory
 $tempdirectory = "$pwd\temp"
 # define services to patch

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,10 @@ set -e
 # detect buildx, set -e will ensure the script stops execution if not found
 docker buildx version
 
+# Enable BuildKit for better build experience and to ensure platform args are populated
+export DOCKER_BUILDKIT=1
+export COMPOSE_DOCKER_CLI_BUILD=1
+
 # define temporary directory
 TEMPDIRECTORY="$PWD/temp"
 


### PR DESCRIPTION
Not sure if we should implement pull #262 as docker should automatically pull the correct architecture and this script should be run on the target machine anyway (as it auto stops/starts all containers).