### PR TITLE
fix error message after build (#263), improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ You may now simply create the file `/path/to/bwdata/docker/docker-compose.overri
 services:
   api:
     image: bitbetter/api
+    pull_policy: never
 
   identity:
     image: bitbetter/identity
+    pull_policy: never
 ```
 
 You'll also want to edit the `/path/to/bwdata/scripts/run.sh` file. In the `function restart()` block, comment out the call to `dockerComposePull`.

--- a/build.sh
+++ b/build.sh
@@ -64,5 +64,5 @@ docker tag bitbetter/api bitbetter/api:$BW_VERSION
 docker tag bitbetter/identity bitbetter/identity:$BW_VERSION
 
 # Remove old instances of the image after a successful build.
-ids=$( docker images bitbetter/* | grep -E -v -- "CREATED|latest|${BW_VERSION}" | awk '{ print $3 }' )
+ids=$( docker image ls --format="{{ .ID }} {{ .Tag }}" 'bitbetter/*' | grep -E -v -- "CREATED|latest|${BW_VERSION}" | awk '{ ids = (ids ? ids FS $1 : $1) } END { print ids }' )
 [ -n "$ids" ] && docker rmi $ids || true


### PR DESCRIPTION
- Fix `Error response from daemon: invalid reference format: repository name (library/DISK) must be lowercase` messages that appeared after building BitBetter.
- Updated `README.md` to align the `docker-compose.override.yml` example with the auto-generated version from `update-bitwarden.sh`.