### PR TITLE
Update to .NET 10.0 and fix certificate validation for Bitwarden server 2026.5.0

### DIFF
--- a/.keys/generate-keys.sh
+++ b/.keys/generate-keys.sh
@@ -15,6 +15,6 @@ DIR=`exec 2>/dev/null;(cd -- "$DIR") && cd -- "$DIR"|| cd "$DIR"; unset PWD; /us
 # Generate new keys
 openssl	req -x509 -newkey rsa:4096 -keyout "$DIR/key.pem" -out "$DIR/cert.cert" -days 36500 -subj '/CN=www.mydom.com/O=My Company Name LTD./C=US'  -outform DER -passout pass:test
 openssl x509 -inform DER -in "$DIR/cert.cert" -out "$DIR/cert.pem"
-openssl pkcs12 -export -out "$DIR/cert.pfx" -inkey "$DIR/key.pem" -in "$DIR/cert.pem" -passin pass:test -passout pass:test
+openssl pkcs12 -export -out "$DIR/cert.pfx" -inkey "$DIR/key.pem" -in "$DIR/cert.pem" -passin pass:test -passout pass:test -certpbe AES-256-CBC -keypbe AES-256-CBC -macalg SHA256
 
 ls

--- a/build.sh
+++ b/build.sh
@@ -70,7 +70,7 @@ else
 	docker run --rm \
 		-v "$DIR/src/bitBetter:/bitBetter" \
 		-w /bitBetter \
-		mcr.microsoft.com/dotnet/sdk:8.0 sh build.sh
+		mcr.microsoft.com/dotnet/sdk:10.0 sh build.sh
 
 	docker build \
 		--no-cache \

--- a/src/bitBetter/Dockerfile
+++ b/src/bitBetter/Dockerfile
@@ -1,7 +1,7 @@
 ARG BITWARDEN_TAG
 FROM ${BITWARDEN_TAG}
 
-COPY bin/Release/net8.0/publish/* /bitBetter/
+COPY bin/Release/net10.0/publish/* /bitBetter/
 COPY ./.keys/cert.cert /newLicensing.cer
 
 RUN set -e; set -x; \

--- a/src/bitBetter/Program.cs
+++ b/src/bitBetter/Program.cs
@@ -85,15 +85,22 @@ namespace BitwardenSelfLicensor
 
             // Use Contains() to handle the hidden Unicode LRM character (\u200E) that Bitwarden
             // prepends to the production thumbprint string literal in LicensingService.cs
-            var instToReplace = ctor.Body.Instructions
+            // Replace ALL occurrences since const fields are inlined at compile time and used in
+            // multiple validation checks (both _creationCertificate and _verificationCertificates)
+            var instructionsToReplace = ctor.Body.Instructions
                 .Where(i => i.OpCode == OpCodes.Ldstr)
-                .FirstOrDefault(i => ((string)i.Operand)
-                    .Contains(existingCert.Thumbprint, StringComparison.OrdinalIgnoreCase));
+                .Where(i => ((string)i.Operand)
+                    .Contains(existingCert.Thumbprint, StringComparison.OrdinalIgnoreCase))
+                .ToList();
 
-            if (instToReplace != null)
+            if (instructionsToReplace.Count > 0)
             {
-                Console.WriteLine($"Replacing thumbprint Ldstr: '{instToReplace.Operand}'");
-                rewriter.Replace(instToReplace, Instruction.Create(OpCodes.Ldstr, newCert.Thumbprint));
+                Console.WriteLine($"Found {instructionsToReplace.Count} thumbprint Ldstr instruction(s) to replace");
+                foreach (var inst in instructionsToReplace)
+                {
+                    Console.WriteLine($"  Replacing: '{inst.Operand}'");
+                    rewriter.Replace(inst, Instruction.Create(OpCodes.Ldstr, newCert.Thumbprint));
+                }
             }
             else
             {

--- a/src/bitBetter/Program.cs
+++ b/src/bitBetter/Program.cs
@@ -66,8 +66,8 @@ namespace BitwardenSelfLicensor
             module.Resources.Add(new EmbeddedResource("Bit.Core.licensing.cer", existingRes.Attributes, certBytes));
             module.Resources.Remove(existingRes);
 
-            var existingCert = new X509Certificate2(existingRes.GetResourceData());
-            var newCert      = new X509Certificate2(certBytes);
+            var existingCert = X509CertificateLoader.LoadCertificate(existingRes.GetResourceData());
+            var newCert      = X509CertificateLoader.LoadCertificate(certBytes);
             Console.WriteLine($"Old thumbprint: {existingCert.Thumbprint}");
             Console.WriteLine($"New thumbprint: {newCert.Thumbprint}");
 
@@ -121,7 +121,7 @@ namespace BitwardenSelfLicensor
 
             // Derive framework name/version from the self-contained includedFrameworks before removing it
             string fwName    = "Microsoft.AspNetCore.App";
-            string fwVersion = "8.0.0";
+            string fwVersion = "10.0.0";
             if (opts["includedFrameworks"] is JsonArray included && included.Count > 0)
             {
                 var first = included[0]!.AsObject();

--- a/src/bitBetter/bitBetter.csproj
+++ b/src/bitBetter/bitBetter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/bitBetter/build.sh
+++ b/src/bitBetter/build.sh
@@ -4,4 +4,4 @@ set -e
 set -x
 
 dotnet restore
-dotnet publish -c Release -o bin/Release/net8.0/publish
+dotnet publish -c Release -o bin/Release/net10.0/publish

--- a/src/licenseGen/Dockerfile
+++ b/src/licenseGen/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 WORKDIR /licenseGen
 
@@ -12,6 +12,6 @@ RUN set -e; set -x; \
 
 FROM bitbetter/api
 
-COPY --from=build /licenseGen/bin/Release/net8.0/publish/* /app/
+COPY --from=build /licenseGen/bin/Release/net10.0/publish/* /app/
 
 ENTRYPOINT [ "dotnet", "/app/licenseGen.dll", "--core", "/app/Core.dll", "--executable", "/app/Api", "--cert", "/cert.pfx" ]

--- a/src/licenseGen/Program.cs
+++ b/src/licenseGen/Program.cs
@@ -141,7 +141,7 @@ namespace BitwardenSelfLicensor
                         buff = Console.ReadLine();
                         if ( buff == "" || buff == "y" || buff == "Y" )
                         {
-                            GenerateUserLicense(new X509Certificate2(cert.Value(), "test"), GetCoreDllPath(), name, email, storage, guid, null);
+                            GenerateUserLicense(X509CertificateLoader.LoadPkcs12FromFile(cert.Value(), "test"), GetCoreDllPath(), name, email, storage, guid, null);
                         }
                         else
                         {
@@ -155,7 +155,7 @@ namespace BitwardenSelfLicensor
                         buff = Console.ReadLine();
                         if ( buff == "" || buff == "y" || buff == "Y" )
                         {
-                            GenerateOrgLicense(new X509Certificate2(cert.Value(), "test"), GetCoreDllPath(), name, email, storage, installid, businessname, null);
+                            GenerateOrgLicense(X509CertificateLoader.LoadPkcs12FromFile(cert.Value(), "test"), GetCoreDllPath(), name, email, storage, installid, businessname, null);
                         }
                         else
                         {
@@ -214,7 +214,7 @@ namespace BitwardenSelfLicensor
                         storageShort = (short) parsedStorage;
                     }
 
-                    GenerateUserLicense(new X509Certificate2(cert.Value(), "test"), GetCoreDllPath(), name.Value, email.Value, storageShort, userId, key.Value);
+                    GenerateUserLicense(X509CertificateLoader.LoadPkcs12FromFile(cert.Value(), "test"), GetCoreDllPath(), name.Value, email.Value, storageShort, userId, key.Value);
 
                     return 0;
                 });
@@ -269,7 +269,7 @@ namespace BitwardenSelfLicensor
                         storageShort = (short) parsedStorage;
                     }
 
-                    GenerateOrgLicense(new X509Certificate2(cert.Value(), "test"), GetCoreDllPath(), name.Value, email.Value, storageShort, installationId, businessName.Value, key.Value);
+                    GenerateOrgLicense(X509CertificateLoader.LoadPkcs12FromFile(cert.Value(), "test"), GetCoreDllPath(), name.Value, email.Value, storageShort, installationId, businessName.Value, key.Value);
 
                     return 0;
                 });

--- a/src/licenseGen/licenseGen.csproj
+++ b/src/licenseGen/licenseGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #281

Bitwarden server 2026.5.0 ships with the .NET 10.0 runtime only, which breaks the fast-patch build in several ways. This PR updates all .NET projects and build pipelines to target `net10.0` and the `dotnet/sdk:10.0` image, fixes the resulting deprecation warnings, modernizes the PKCS#12 certificate generation, and fixes a runtime certificate validation error caused by incomplete IL thumbprint patching.

---

### Changes

**1. Update .NET target from 8.0 to 10.0**

Bitwarden 2026.5.0 no longer includes the .NET 8.0 runtime, so `dotnet bitBetter.dll` fails inside the patched container with:

```
You must install or update .NET to run this application.
Framework: 'Microsoft.NETCore.App', version '8.0.0' (x64)
The following frameworks were found:
  10.0.8 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
```

Updated all project files, build scripts, and Dockerfiles to target `net10.0` / `dotnet/sdk:10.0`:
- `build.sh` — SDK image for the patcher build container
- `src/bitBetter/bitBetter.csproj` — target framework
- `src/bitBetter/build.sh` — publish output path
- `src/bitBetter/Dockerfile` — COPY path for published binaries
- `src/licenseGen/licenseGen.csproj` — target framework
- `src/licenseGen/Dockerfile` — SDK image and COPY path

**2. Fix SYSLIB0057 — obsolete `X509Certificate2` constructors**

.NET 9/10 marks the `new X509Certificate2(byte[])` and `new X509Certificate2(string, string)` constructors as obsolete ([SYSLIB0057](https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0057)). Replaced with the new `X509CertificateLoader` API:

- `src/bitBetter/Program.cs` — `X509CertificateLoader.LoadCertificate(byte[])` for DER certificate data
- `src/licenseGen/Program.cs` — `X509CertificateLoader.LoadPkcs12FromFile(path, password)` for PFX files with private keys

Also updated the `FixRuntimeConfig` fallback framework version from `8.0.0` to `10.0.0`.

**3. Modernize PKCS#12 certificate generation**

OpenSSL 3.x (shipped in the Bitwarden setup container) rejects the legacy RC2-40-CBC algorithm that `openssl pkcs12 -export` uses by default:

```
PKCS7 Encrypted data: pbeWithSHA1And40BitRC2-CBC, Iteration 2048
Error outputting keys and certificates
error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported
```

Added modern encryption flags to `.keys/generate-keys.sh`:
```
-certpbe AES-256-CBC -keypbe AES-256-CBC -macalg SHA256
```

This generates PKCS#12 bundles compatible with both OpenSSL 1.1.1 and 3.x without requiring the legacy provider.

**4. Fix certificate validation by replacing all thumbprint occurrences**

Bitwarden's `LicensingService` performs two separate validation checks in its constructor:

1. Validates `_creationCertificate.Thumbprint` matches the expected value
2. Validates all certificates in `_verificationCertificates` have thumbprints in an allowed set

The allowed thumbprints are defined as `const` fields, which the C# compiler inlines at every usage site in the IL code. The previous patcher used `FirstOrDefault()` and only replaced the **first** `Ldstr` instruction containing the old thumbprint. The second validation check still saw the original production thumbprint and threw:

```
System.Exception: Invalid license verifying certificate.
   at Bit.Core.Billing.Services.LicensingService..ctor(...)
```

Updated the patcher to find and replace **all** matching `Ldstr` instructions using `.Where().Where().ToList()` + a foreach loop.

---

### Testing

I tested the full build pipeline against Bitwarden server 2026.5.0:
- `./build.sh` completes successfully with `net10.0` target
- Build output confirms multiple thumbprint replacements: `Found 2 thumbprint Ldstr instruction(s) to replace`
- Both `bitbetter/api:2026.5.0` and `bitbetter/identity:2026.5.0` images build and start cleanly
- No `Invalid license verifying certificate` errors in container logs
- Login and license operations work as expected

### Note for existing users

Users with certificates generated by older versions of `generate-keys.sh` (using legacy RC2-CBC encryption) must delete their `.keys/` directory and re-run `build.sh` to regenerate keys with the modern algorithm. Existing PFX files encrypted with RC2-CBC will continue to cause OpenSSL 3.x errors.