### PR TITLE
Bump to .NET 10 and patch all LicensingService thumbprint Ldstr's (Bitwarden 2026.5.0+ compat)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,7 +70,7 @@ else
 	docker run --rm \
 		-v "$DIR/src/bitBetter:/bitBetter" \
 		-w /bitBetter \
-		mcr.microsoft.com/dotnet/sdk:8.0 sh build.sh
+		mcr.microsoft.com/dotnet/sdk:10.0 sh build.sh
 
 	docker build \
 		--no-cache \

--- a/src/bitBetter/Dockerfile
+++ b/src/bitBetter/Dockerfile
@@ -1,7 +1,7 @@
 ARG BITWARDEN_TAG
 FROM ${BITWARDEN_TAG}
 
-COPY bin/Release/net8.0/publish/* /bitBetter/
+COPY bin/Release/net10.0/publish/* /bitBetter/
 COPY ./.keys/cert.cert /newLicensing.cer
 
 RUN set -e; set -x; \

--- a/src/bitBetter/Program.cs
+++ b/src/bitBetter/Program.cs
@@ -85,20 +85,24 @@ namespace BitwardenSelfLicensor
 
             // Use Contains() to handle the hidden Unicode LRM character (\u200E) that Bitwarden
             // prepends to the production thumbprint string literal in LicensingService.cs
-            var instToReplace = ctor.Body.Instructions
+            var instsToReplace = ctor.Body.Instructions
                 .Where(i => i.OpCode == OpCodes.Ldstr)
-                .FirstOrDefault(i => ((string)i.Operand)
-                    .Contains(existingCert.Thumbprint, StringComparison.OrdinalIgnoreCase));
+                .Where(i => ((string)i.Operand)
+                    .Contains(existingCert.Thumbprint, StringComparison.OrdinalIgnoreCase))
+                .ToList();
 
-            if (instToReplace != null)
+            if (instsToReplace.Count == 0)
             {
-                Console.WriteLine($"Replacing thumbprint Ldstr: '{instToReplace.Operand}'");
-                rewriter.Replace(instToReplace, Instruction.Create(OpCodes.Ldstr, newCert.Thumbprint));
+                Console.Error.WriteLine("ERROR: No thumbprint Ldstr found in LicensingService ctor");
+                return 1;
             }
-            else
+
+            foreach (var inst in instsToReplace)
             {
-                Console.WriteLine("WARNING: Thumbprint Ldstr not found — cert resource replaced anyway");
+                Console.WriteLine($"Replacing thumbprint Ldstr: '{inst.Operand}'");
+                rewriter.Replace(inst, Instruction.Create(OpCodes.Ldstr, newCert.Thumbprint));
             }
+            Console.WriteLine($"Replaced {instsToReplace.Count} Ldstr instance(s).");
 
             module.Write(coreDllPath);
             Console.WriteLine("Done.");

--- a/src/bitBetter/bitBetter.csproj
+++ b/src/bitBetter/bitBetter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/bitBetter/build.sh
+++ b/src/bitBetter/build.sh
@@ -4,4 +4,4 @@ set -e
 set -x
 
 dotnet restore
-dotnet publish -c Release -o bin/Release/net8.0/publish
+dotnet publish -c Release -o bin/Release/net10.0/publish


### PR DESCRIPTION
## Summary

Bitwarden 2026.5.0 introduced two breaking changes that prevent the current
fast-patch flow from producing working images:

1. **Base images ship with .NET 10 only.** The patcher binary built against
   `net8.0` errors at patch time: `Framework: Microsoft.NETCore.App, version
   '8.0.0' (x64)` not found, only `10.0.x` present.
2. **LicensingService gained a second cert-thumbprint check.** The ctor
   (refactored to `Bit.Core.Billing.Services.LicensingService` in 2026.5.0)
   builds a hardcoded `HashSet<string>` allow-list of Bitwarden's prod and
   dev thumbprints, and throws `Invalid license verifying certificate.` if
   any cert in `_verificationCertificates` has a thumbprint not in it. The
   previous patcher's `FirstOrDefault` replaced only the first matching
   Ldstr, leaving the allow-list literal untouched. Identity crashed on
   every `/.well-known/openid-configuration` request, blocking login.

## What changed

- **.NET 10 bump** across `bitBetter.csproj`, both `Dockerfile`s, and both
  build scripts.
- **Replace all matching Ldstr's** in the `LicensingService` ctor body, not
  just the first.
- **Fail-loud** when no Ldstr is found, replacing the prior
  warn-and-continue behavior. (This would have surfaced 2026.5.0 at build
  time rather than at first login.)

## Verification

Tested against `ghcr.io/bitwarden/{api,identity}:2026.5.0` on x86_64
Debian 12. Patcher logs `Replaced 2 Ldstr instance(s).` for each image.
Identity boots healthy with no `Invalid license verifying certificate`
exception, `/api/version` returns `2026.5.0`, and existing organization
licenses validate.

## Decompiled snippet that motivated the LicensingService change

From `bitbetter/identity:2026.5.0` after .NET 10 fix but before the
multi-Ldstr fix (decompiled via ilspycmd):

```csharp
public LicensingService(/* DI args */)
{
    // ... DI assignments ...

    // Patcher already rewrites this Ldstr to the user's thumbprint:
    string thumbprint = environment.IsDevelopment()
        ? "207E64A231E8AA32AAF68A61037C075EBEBD553F"
        : "B34876439FCDA2846505B2EFBBA6C4A951313EBE";

    // ... _creationCertificate is loaded from the (now user-provided)
    // embedded "licensing.cer" resource ...
    _verificationCertificates.Add(_creationCertificate);

    // First check — passes after the existing single-Ldstr patch:
    if (_creationCertificate == null ||
        !_creationCertificate.Thumbprint.Equals(
            CoreHelpers.CleanCertificateThumbprint(thumbprint),
            StringComparison.InvariantCultureIgnoreCase))
    {
        throw new Exception("Invalid licensing certificate.");
    }

    // NEW in 2026.5.0 — second, independent allow-list check.
    // The old patcher's FirstOrDefault missed THIS Ldstr (the prod
    // thumbprint inside the HashSet initializer), so the throw below
    // fires for any user-supplied cert.
    HashSet<string> allowedThumbprints = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
    {
        CoreHelpers.CleanCertificateThumbprint("\u200eB34876439FCDA2846505B2EFBBA6C4A951313EBE"),
        CoreHelpers.CleanCertificateThumbprint("207E64A231E8AA32AAF68A61037C075EBEBD553F")
    };
    if (_verificationCertificates == null
        || _verificationCertificates.Count == 0
        || _verificationCertificates.Any(c => !allowedThumbprints.Contains(c.Thumbprint)))
    {
        throw new Exception("Invalid license verifying certificate.");
    }

    // ... LicenseDirectory check ...
}
```
