### PR TITLE
Update URL with version information

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,12 @@
 set -e
 DIR=`dirname "$0"`
 DIR=`exec 2>/dev/null;(cd -- "$DIR") && cd -- "$DIR"|| cd "$DIR"; unset PWD; /usr/bin/pwd || /bin/pwd || pwd`
-BW_VERSION=$(curl -sL https://raw.githubusercontent.com/bitwarden/self-host/refs/heads/main/version.json | grep '^ *"'coreVersion'":' | awk -F\: '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
+
+# Check prerequisite libraries and executables
+for cmd in docker curl openssl jq openssl; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "Error: '$cmd' is required but not installed." >&2; exit 1; }
+done
+BW_VERSION=$(curl -sL https://raw.githubusercontent.com/bitwarden/self-host/refs/heads/main/version.json | jq -r '.versions.coreVersion')
 
 echo "Building BitBetter for BitWarden version $BW_VERSION"
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -e
 DIR=`dirname "$0"`
 DIR=`exec 2>/dev/null;(cd -- "$DIR") && cd -- "$DIR"|| cd "$DIR"; unset PWD; /usr/bin/pwd || /bin/pwd || pwd`
-BW_VERSION=$(curl -sL https://go.btwrdn.co/bw-sh-versions | grep '^ *"'coreVersion'":' | awk -F\: '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
+BW_VERSION=$(curl -sL https://raw.githubusercontent.com/bitwarden/self-host/refs/heads/main/version.json | grep '^ *"'coreVersion'":' | awk -F\: '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
 
 echo "Building BitBetter for BitWarden version $BW_VERSION"
 

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,10 @@ DIR=`exec 2>/dev/null;(cd -- "$DIR") && cd -- "$DIR"|| cd "$DIR"; unset PWD; /us
 for cmd in docker curl openssl jq; do
     command -v "$cmd" >/dev/null 2>&1 || { echo "Error: '$cmd' is required but not installed." >&2; exit 1; }
 done
-BW_VERSION=$(curl -sL https://raw.githubusercontent.com/bitwarden/self-host/refs/heads/main/version.json | jq -r '.versions.coreVersion')
+if [ "${BITBETTER_BUILD_FROM_SOURCE:-0}" = "1" ]; then
+    command -v git >/dev/null 2>&1 || { echo "Error: 'git' is required for BITBETTER_BUILD_FROM_SOURCE=1 but not installed." >&2; exit 1; }
+fi
+BW_VERSION=$(curl -fsSL https://raw.githubusercontent.com/bitwarden/self-host/refs/heads/main/version.json | jq -er '.versions.coreVersion')
 
 echo "Building BitBetter for BitWarden version $BW_VERSION"
 

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ DIR=`dirname "$0"`
 DIR=`exec 2>/dev/null;(cd -- "$DIR") && cd -- "$DIR"|| cd "$DIR"; unset PWD; /usr/bin/pwd || /bin/pwd || pwd`
 
 # Check prerequisite libraries and executables
-for cmd in docker curl openssl jq openssl; do
+for cmd in docker curl openssl jq; do
     command -v "$cmd" >/dev/null 2>&1 || { echo "Error: '$cmd' is required but not installed." >&2; exit 1; }
 done
 BW_VERSION=$(curl -sL https://raw.githubusercontent.com/bitwarden/self-host/refs/heads/main/version.json | jq -r '.versions.coreVersion')

--- a/update-bitwarden.sh
+++ b/update-bitwarden.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e 
+set -e
 
 ask () {
   local __resultVar=$1
@@ -17,7 +17,7 @@ for cmd in docker curl openssl jq; do
     command -v "$cmd" >/dev/null 2>&1 || { echo "Error: '$cmd' is required but not installed." >&2; exit 1; }
 done
 
-BW_VERSION=$(curl -sL https://raw.githubusercontent.com/bitwarden/self-host/refs/heads/main/version.json | jq -r '.versions.coreVersion')
+BW_VERSION=$(curl -fsSL https://raw.githubusercontent.com/bitwarden/self-host/refs/heads/main/version.json | jq -er '.versions.coreVersion')
 
 echo "Starting Bitwarden update, newest server version: $BW_VERSION"
 

--- a/update-bitwarden.sh
+++ b/update-bitwarden.sh
@@ -13,7 +13,7 @@ ask () {
 SCRIPT_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Check prerequisite libraries and executables
-for cmd in docker curl openssl jq openssl; do
+for cmd in docker curl openssl jq; do
     command -v "$cmd" >/dev/null 2>&1 || { echo "Error: '$cmd' is required but not installed." >&2; exit 1; }
 done
 

--- a/update-bitwarden.sh
+++ b/update-bitwarden.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e 
+
 ask () {
   local __resultVar=$1
   local __result="$2"
@@ -9,7 +11,13 @@ ask () {
 }
 
 SCRIPT_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-BW_VERSION=$(curl -sL https://raw.githubusercontent.com/bitwarden/self-host/refs/heads/main/version.json | grep '^ *"'coreVersion'":' | awk -F\: '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
+
+# Check prerequisite libraries and executables
+for cmd in docker curl openssl jq openssl; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "Error: '$cmd' is required but not installed." >&2; exit 1; }
+done
+
+BW_VERSION=$(curl -sL https://raw.githubusercontent.com/bitwarden/self-host/refs/heads/main/version.json | jq -r '.versions.coreVersion')
 
 echo "Starting Bitwarden update, newest server version: $BW_VERSION"
 

--- a/update-bitwarden.sh
+++ b/update-bitwarden.sh
@@ -9,7 +9,7 @@ ask () {
 }
 
 SCRIPT_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-BW_VERSION=$(curl -sL https://go.btwrdn.co/bw-sh-versions | grep '^ *"'coreVersion'":' | awk -F\: '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
+BW_VERSION=$(curl -sL https://raw.githubusercontent.com/bitwarden/self-host/refs/heads/main/version.json | grep '^ *"'coreVersion'":' | awk -F\: '{ print $2 }' | sed -e 's/,$//' -e 's/^"//' -e 's/"$//')
 
 echo "Starting Bitwarden update, newest server version: $BW_VERSION"
 


### PR DESCRIPTION
The previous URL is no longer working. Instead of the site redirect, switching directly to the official GitHub repository of Bitwarden to download the latest version information.