### PR TITLE
Recreate BitBetter containers before pruning images

### DIFF
--- a/update-bitwarden.sh
+++ b/update-bitwarden.sh
@@ -83,6 +83,21 @@ echo "Patching bitwarden.sh completed..."
 
 ./bitwarden.sh update
 
+# A Bitwarden update may report "Update not needed" when rebuilding BitBetter
+# for the currently installed Bitwarden version. In that case, the existing
+# containers remain attached to the old image IDs and the newly built images
+# are considered unused by `docker image prune -a`.
+if [[ $REBUILD_BB =~ ^[Yy]$ ]]
+then
+    echo "Recreating BitBetter containers with the newly built images..."
+    cd "$BITWARDEN_BASE/bwdata/docker"
+    docker compose up -d \
+        --no-deps \
+        --force-recreate \
+        api identity
+    cd "$BITWARDEN_BASE"
+fi
+
 # Prune Docker images without at least one container associated to them.
 echo "Pruning Docker images without at least one container associated to them..."
 docker image prune -a


### PR DESCRIPTION
## Problem

When BitBetter rebuilds images for the currently installed Bitwarden
version, `bitwarden.sh update` may report `Update not needed`.

The existing API and Identity containers then remain attached to the old
image IDs. As a result, the subsequent `docker image prune -a` can remove
the newly built images because no containers reference them yet.

## Solution

When BitBetter images were rebuilt, force-recreate the `api` and `identity`
services before pruning unused images.

This ensures that the containers use the newly built images before
`docker image prune -a` runs.``