### PR TITLE
Fix missing Data assembly in licenseGen for newer Bitwarden containers

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -22,6 +22,10 @@ if (Test-Path -Path "$pwd\src\licenseGen\Core.dll" -PathType Leaf) {
 	Remove-Item "$pwd\src\licenseGen\Core.dll" -Force
 }
 
+if (Test-Path -Path "$pwd\src\licenseGen\Data.dll" -PathType Leaf) {
+	Remove-Item "$pwd\src\licenseGen\Data.dll" -Force
+}
+
 if (Test-Path -Path "$pwd\src\licenseGen\cert.pfx" -PathType Leaf) {
 	Remove-Item "$pwd\src\licenseGen\cert.pfx" -Force
 }
@@ -131,8 +135,9 @@ if (Test-Path -Path "$pwd\.servers\serverlist.txt" -PathType Leaf) {
 # remove our bitBetter image
 docker image rm bitbetter/bitbetter
 
-# copy our patched library to the licenseGen source directory
+# copy our patched library and its dependency assemblies to the licenseGen source directory
 Copy-Item "$tempdirectory\Identity\Core.dll" -Destination "$pwd\src\licenseGen"
+Copy-Item "$tempdirectory\Identity\Data.dll" -Destination "$pwd\src\licenseGen"
 Copy-Item "$pwd\.keys\cert.pfx" -Destination "$pwd\src\licenseGen"
 
 # build the licenseGen
@@ -140,6 +145,7 @@ docker build -t bitbetter/licensegen "$pwd\src\licenseGen"
 
 # clean the licenseGen source directory
 Remove-Item "$pwd\src\licenseGen\Core.dll" -Force
+Remove-Item "$pwd\src\licenseGen\Data.dll" -Force
 Remove-Item "$pwd\src\licenseGen\cert.pfx" -Force
 
 # remove our temporary directory

--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,10 @@ if [ -f "$PWD/src/licenseGen/Core.dll" ]; then
 	rm -f "$PWD/src/licenseGen/Core.dll"
 fi
 
+if [ -f "$PWD/src/licenseGen/Data.dll" ]; then
+	rm -f "$PWD/src/licenseGen/Data.dll"
+fi
+
 if [ -f "$PWD/src/licenseGen/cert.pfx" ]; then
 	rm -f "$PWD/src/licenseGen/cert.pfx"
 fi
@@ -134,8 +138,9 @@ fi
 # remove our bitBetter image
 docker image rm bitbetter/bitbetter
 
-# copy our patched library to the licenseGen source directory
+# copy our patched library and its dependency assemblies to the licenseGen source directory
 cp -f "$TEMPDIRECTORY/Identity/Core.dll" "$PWD/src/licenseGen"
+cp -f "$TEMPDIRECTORY/Identity/Data.dll" "$PWD/src/licenseGen"
 cp -f "$PWD/.keys/cert.pfx" "$PWD/src/licenseGen"
 
 # build the licenseGen
@@ -143,6 +148,7 @@ docker build -t bitbetter/licensegen "$PWD/src/licenseGen"
 
 # clean the licenseGen source directory
 rm -f "$PWD/src/licenseGen/Core.dll"
+rm -f "$PWD/src/licenseGen/Data.dll"
 rm -f "$PWD/src/licenseGen/cert.pfx"
 
 # remove our temporary directory

--- a/src/licenseGen/Dockerfile
+++ b/src/licenseGen/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /licenseGen
 
 COPY . /licenseGen
 COPY Core.dll /app/
+COPY Data.dll /app/
 COPY cert.pfx /app/
 
 RUN dotnet restore

--- a/src/licenseGen/Program.cs
+++ b/src/licenseGen/Program.cs
@@ -261,6 +261,7 @@ internal class Program
 
 		try
 		{
+			AssemblyLoadContext.Default.Resolving += ResolveCoreDependency;
 			App.HelpOption("-? | -h | --help");
 			return App.Execute(args);
 		}
@@ -344,10 +345,26 @@ internal class Program
 		return false;
 	}
 
+	private static String CoreDirectory = String.Empty;
+
+	private static Assembly LoadCoreAssembly(String corePath)
+	{
+		String path = Path.GetFullPath(corePath);
+		CoreDirectory = Path.GetDirectoryName(path) ?? String.Empty;
+		return AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
+	}
+
+	private static Assembly ResolveCoreDependency(AssemblyLoadContext context, AssemblyName name)
+	{
+		if (CoreDirectory == String.Empty || name.Name == null) return null;
+		String candidate = Path.Combine(CoreDirectory, name.Name + ".dll");
+		return File.Exists(candidate) ? context.LoadFromAssemblyPath(candidate) : null;
+	}
+
 	private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 	private static void GenerateUserLicense(X509Certificate2 cert, String corePath, String userName, String email, Int16 storage, Guid userId, String key)
 	{
-		Assembly core = AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.GetFullPath(corePath));
+		Assembly core = LoadCoreAssembly(corePath);
 
 		Type type = core.GetType("Bit.Core.Billing.Models.Business.UserLicense");
 		Type licenseTypeEnum = core.GetType("Bit.Core.Enums.LicenseType");
@@ -402,7 +419,7 @@ internal class Program
 	}
 	private static void GenerateOrgLicense(X509Certificate2 cert, String corePath, String userName, String email, Int16 storage, Guid installId, String businessName, String key)
 	{
-		Assembly core = AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.GetFullPath(corePath));
+		Assembly core = LoadCoreAssembly(corePath);
 		Type type = core.GetType("Bit.Core.Billing.Organizations.Models.OrganizationLicense");
 		Type licenseTypeEnum = core.GetType("Bit.Core.Enums.LicenseType");
 		Type planTypeEnum = core.GetType("Bit.Core.Billing.Enums.PlanType");


### PR DESCRIPTION
Fix missing Data assembly in licenseGen for newer Bitwarden containers

Newer Bitwarden containers split license model types into a separate
Data assembly. When System.Text.Json reflects over the UserLicense
deserialization constructor during JsonSerializer.Serialize, it tries
to resolve that assembly, but only the patched Core.dll was shipped
with the licenseGen image, causing:

    System.IO.FileNotFoundException: Could not load file or assembly
    'Data, Version=0.0.1.0, Culture=neutral, PublicKeyToken=null'

- build.sh / build.ps1: also copy the extracted Data.dll into the
  licenseGen source directory (with matching cleanup)
- licenseGen Dockerfile: COPY Data.dll into /app
- Program.cs: add an AssemblyLoadContext.Resolving fallback that loads
  dependency assemblies from the Core.dll directory, so any future
  assembly splits are resolved automatically

This fix was developed with AI assistance